### PR TITLE
Remove deprecated jekyll configurations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,4 @@
-auto: true
 safe: true
-server: true
 markdown: kramdown
 pygments: true
 permalink: /:title.html


### PR DESCRIPTION
Removing deprecated jekyll configurations `server` and `auto` in `_config.yml` will solve the warnings metioned at [Issue #26](https://github.com/shower/jekyller/issues/26)
